### PR TITLE
Add spinner for apple loading

### DIFF
--- a/src/components/Apple.tsx
+++ b/src/components/Apple.tsx
@@ -8,6 +8,7 @@ import { useDebounce } from '../hooks/useDebounce'
 import { useApplePosition } from '../hooks/useApplePosition'
 import { useShadowSetup } from '../hooks/useShadowSetup'
 import ErrorScreen from './ErrorScreen'
+import Spinner from './Spinner'
 const COUNTER_RESET_VALUE = 1000000 // Предотвращает переполнение счетчика
 const DEBOUNCE_DELAY = 16 // ~60fps для debouncing позиции
 /**
@@ -45,7 +46,7 @@ const Apple: React.FC = () => {
     return <ErrorScreen message={loadError.message} />
   }
   if (!gltf?.scene) {
-    return <ErrorScreen message='Модель яблока не загружена' />
+    return <Spinner />
   }
   return <primitive object={gltf.scene} position={debouncedPosition} scale={scaleArray} />
 }

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Html, useProgress } from '@react-three/drei'
+import '../styles/spinner.css'
+
+const Spinner: React.FC = () => {
+  const { progress } = useProgress()
+  return (
+    <Html center>
+      <div className='spinner-container'>
+        <i className='fa-solid fa-spinner fa-spin'></i>
+        <p>{progress.toFixed(0)}%</p>
+      </div>
+    </Html>
+  )
+}
+
+export default Spinner

--- a/src/styles/spinner.css
+++ b/src/styles/spinner.css
@@ -1,0 +1,13 @@
+.spinner-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #b8c6dc;
+  font-size: 2vmin;
+}
+
+.spinner-container i {
+  font-size: 4vmin;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add `Spinner` component using `useProgress`
- show spinner while apple model loads

## Testing
- `npm run build` *(fails: Cannot find module due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686bb2fcf578833286cf3b5069ea9b5c