### PR TITLE
Refactor snake head-body collision iteration

### DIFF
--- a/src/engine/events/snakeHeadBodyContactEvent.ts
+++ b/src/engine/events/snakeHeadBodyContactEvent.ts
@@ -11,9 +11,10 @@ import * as SNAKE from '../snake/snake'
  * @returns Измененные в результате контакта параметры головы змейки
  */
 function snakeHeadBodyContactEvent(snakeHead: SnakeHeadCoord): SnakeHeadCoord {
-  const currentSnakeLength = SNAKE.getSnakeBodyCoord().length
+  const snakeBody = SNAKE.getSnakeBodyCoord()
+  const currentSnakeLength = snakeBody.length
   const maxSnakeBodyLength = currentSnakeLength + (currentSnakeLength % 2) - 2
-  SNAKE.getSnakeBodyCoord().forEach((pos: number[], index: number) => {
+  snakeBody.forEach((pos: number[], index: number) => {
     if (
       index !== 0 &&
       index !== maxSnakeBodyLength &&


### PR DESCRIPTION
## Summary
- avoid calling `getSnakeBodyCoord` multiple times in `snakeHeadBodyContactEvent`
- use the cached `snakeBody` array for determining maximum length
- iterate directly over `snakeBody`

## Testing
- `npm run build` *(fails: Cannot find module 'three' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686bb8898f9c8332b8625dff42c09aa1