### PR TITLE
Remove redundant step reset in body contact event

### DIFF
--- a/src/engine/events/snakeHeadBodyContactEvent.ts
+++ b/src/engine/events/snakeHeadBodyContactEvent.ts
@@ -26,8 +26,6 @@ function snakeHeadBodyContactEvent(snakeHead: SnakeHeadCoord): SnakeHeadCoord {
         snakeHead.snakeHeadCoordY - snakeHead.snakeHeadStepY
       snakeHead.snakeHeadCoordX =
         snakeHead.snakeHeadCoordX - snakeHead.snakeHeadStepX
-      snakeHead.snakeHeadStepX = 0
-      snakeHead.snakeHeadStepY = 0
       isContact(snakeHead, 'oneself')
       break
     }


### PR DESCRIPTION
## Summary
- remove redundant snake step reset in `snakeHeadBodyContactEvent`
- rely on `isContact` to zero the step values instead

## Testing
- `npm run build` *(fails: Cannot find module 'three' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686bbb198890833295df20c8eae943c0