### PR TITLE
Improve snake position tolerance

### DIFF
--- a/src/animations/snakeAnimation/snakeStepSetting.ts
+++ b/src/animations/snakeAnimation/snakeStepSetting.ts
@@ -20,6 +20,7 @@ import {
 import { getSnakeUnitPosition } from './bodyAnimations/snakeBodyProps'
 import { getDiff, setDiff } from './bodyAnimations/snakeDiff'
 import { getCounterHead } from './headAnimations/snakeHeadLocation'
+import { POSITION_EPSILON } from '../../engine/snake/setSnakePosition'
 
 const snakeTurnAround = [0, 0]
 
@@ -47,7 +48,12 @@ export const snakeStepSetting = (step: snakeSteps[]): snakeSteps[] => {
   let newStep: snakeSteps[] = [...step]
 
   // Функция работает только в момент нахождения рендера в узлах игрового поля
-  if (getCounterHead()[0] === 0 && getCounterHead()[1] === 0 && checkTimerWorking()) {
+  const [cx, cy] = getCounterHead()
+  if (
+    Math.abs(cx) < POSITION_EPSILON &&
+    Math.abs(cy) < POSITION_EPSILON &&
+    checkTimerWorking()
+  ) {
     // newStep = [...step]
     // console.log('new step: ')
     // console.log(

--- a/src/engine/snake/setSnakePosition.ts
+++ b/src/engine/snake/setSnakePosition.ts
@@ -1,6 +1,8 @@
 import { checkTimerWorking } from '../time/isTimer'
 import { advanceSnake } from './moveSnake'
 
+export const POSITION_EPSILON = 1e-3
+
 /**
  * тип, описывающий счётчик шагов головы 3D змейки по X и Y
  * при её движении от центра одной клетки к центру другой
@@ -29,6 +31,9 @@ export const setSnakePosition = (props: positionCounter): positionCounter => {
       advanceSnake()
     }
   }
+
+  if (Math.abs(counterX) < POSITION_EPSILON) counterX = 0
+  if (Math.abs(counterY) < POSITION_EPSILON) counterY = 0
 
   return { counterX, counterY }
 }


### PR DESCRIPTION
## Summary
- expose `POSITION_EPSILON` from `setSnakePosition`
- zero position counters when they're very small
- honor that epsilon when evaluating commands in `snakeStepSetting`

## Testing
- `npm run build` *(fails: Cannot find module '@react-three/fiber' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686e90f950c083329fd3ac41ce5bc158